### PR TITLE
Opção de ditar cargos adicionada

### DIFF
--- a/src/app/services/cargo.service.ts
+++ b/src/app/services/cargo.service.ts
@@ -22,6 +22,16 @@ export class CargoService {
     );
   }
 
+  public findById(idCargo: string): Observable<Cargo> {
+    return this.http.get<Cargo>(`${API_CONFIG.baseUrl}/cargos/${idCargo}`).pipe(
+      catchError(error => {
+        alert("Erro ao buscar dados de cargos.");
+        console.error(error);
+        return EMPTY;
+      })
+    );
+  }
+
   public create(cargo: Cargo): Observable<Cargo> {
     return this.http.post<Cargo>(`${API_CONFIG.baseUrl}/cargos`, cargo).pipe(
       catchError(error => {
@@ -31,4 +41,25 @@ export class CargoService {
       })
     );
   }
+
+  public delete(idCargo: number): Observable<Cargo> {
+    return this.http.delete<Cargo>(`${API_CONFIG.baseUrl}/cargo/${idCargo}`).pipe(
+      catchError(error => {
+        alert("Erro ao excluir cargo.");
+        console.error(error);
+        return EMPTY;
+      })
+    );
+  }
+
+  public update(cargo: Cargo): Observable<Cargo> {
+    return this.http.put<Cargo>(`${API_CONFIG.baseUrl}/cargos/${cargo.idCargo}`, cargo).pipe(
+      catchError(error => {
+        alert("Erro ao editar cargo.");
+        console.error(error);
+        return EMPTY;
+      })
+    );
+  }
+
 }

--- a/src/app/views/cargos/cargos-routing.module.ts
+++ b/src/app/views/cargos/cargos-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CargosComponent } from './cargos/cargos.component';
+import { EditCargoComponent } from './edit-cargo/edit-cargo.component';
 import { NewCargoComponent } from './new-cargo/new-cargo.component';
 
 const routes: Routes = [
@@ -11,6 +12,10 @@ const routes: Routes = [
   {
     path: 'new',
     component: NewCargoComponent
+  },
+  {
+    path: 'edit/:idCargo',
+    component: EditCargoComponent
   }
 ];
 

--- a/src/app/views/cargos/cargos.module.ts
+++ b/src/app/views/cargos/cargos.module.ts
@@ -6,20 +6,23 @@ import { CargosComponent } from './cargos/cargos.component';
 import { ComponentsModule } from 'src/app/components/components.module';
 import { MaterialModule } from 'src/app/shared/material/material.module';
 import { NewCargoComponent } from './new-cargo/new-cargo.component';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { EditCargoComponent } from './edit-cargo/edit-cargo.component';
 
 
 @NgModule({
   declarations: [
     CargosComponent,
-    NewCargoComponent
+    NewCargoComponent,
+    EditCargoComponent
   ],
   imports: [
     CommonModule,
     CargosRoutingModule,
     ComponentsModule,
     MaterialModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    FormsModule
   ]
 })
 export class CargosModule { }

--- a/src/app/views/cargos/cargos/cargos.component.html
+++ b/src/app/views/cargos/cargos/cargos.component.html
@@ -31,7 +31,7 @@
             <ng-container matColumnDef="editar">
                 <th mat-header-cell *matHeaderCellDef> Editar </th>
                 <td mat-cell *matCellDef="let cargo">
-                    <a mat-icon-button [routerLink]="['edit', cargo.id]">
+                    <a mat-icon-button [routerLink]="['edit', cargo.idCargo]">
                         <i class="material-icons">edit</i>
                     </a>
                 </td>

--- a/src/app/views/cargos/edit-cargo/edit-cargo.component.css
+++ b/src/app/views/cargos/edit-cargo/edit-cargo.component.css
@@ -1,0 +1,13 @@
+form a,
+form button {
+    margin-left: 20px;
+    float: right;
+}
+
+.section {
+    margin-bottom: 20px;
+}
+
+.margin {
+    margin-right: 15px;
+}

--- a/src/app/views/cargos/edit-cargo/edit-cargo.component.html
+++ b/src/app/views/cargos/edit-cargo/edit-cargo.component.html
@@ -1,0 +1,22 @@
+<app-nav-bar>
+    <ng-container>
+        <h2>Editar Cargo</h2>
+        <form #formEditCargo="ngForm">
+            <mat-form-field class="full-width" appearance="fill">
+                <mat-label>Nome do Cargo</mat-label>
+                <input type="text" name="nome" matInput name="nome" [(ngModel)]="cargo.nome" required>
+            </mat-form-field>
+            <mat-form-field class="full-width" appearance="fill">
+                <mat-label>Descrição</mat-label>
+                <textarea name="descricao" matInput name="descricao" rows="2" [(ngModel)]="cargo.descricao" required></textarea>
+            </mat-form-field>
+            <mat-form-field class="full-width" appearance="fill">
+                <mat-label>Salário</mat-label>
+                <input type="number" name="salario" matInput name="salario" [(ngModel)]="cargo.salario" required>
+            </mat-form-field>
+
+            <button type="submit" mat-raised-button color="primary" (click)="update(formEditCargo)">Editar</button>
+            <a type="button" mat-raised-button color="warn" routerLink="/cargos">Cancelar</a>
+        </form>
+    </ng-container>
+</app-nav-bar>

--- a/src/app/views/cargos/edit-cargo/edit-cargo.component.ts
+++ b/src/app/views/cargos/edit-cargo/edit-cargo.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
+import { ActivatedRoute, Route, Router } from '@angular/router';
+import { Cargo } from 'src/app/models/cargo';
+import { CargoService } from 'src/app/services/cargo.service';
+
+@Component({
+  selector: 'app-edit-cargo',
+  templateUrl: './edit-cargo.component.html',
+  styleUrls: ['./edit-cargo.component.css']
+})
+export class EditCargoComponent implements OnInit {
+
+  public cargo: Cargo = {
+    nome: '',
+    descricao: '',
+    salario: 0
+  };
+
+  constructor(
+    private route: ActivatedRoute,
+    private cargoService: CargoService,
+    private router: Router
+    ) { }
+
+  ngOnInit(): void {
+    this.initilizeFields ();
+  }
+
+  private initilizeFields(): void {
+    const idCargo: string | null = this.route.snapshot.paramMap.get('idCargo');
+    if(idCargo) {
+      this.cargoService.findById(idCargo).subscribe(cargo => {
+        this.cargo = cargo;
+      })
+    }
+  }
+
+  public update(formEditCargo: NgForm): void {
+    if(formEditCargo.valid) {
+      this.cargoService.update(this.cargo).subscribe(() => {
+        alert("Cargo editado.");
+        this.router.navigate(["/cargos"]);
+      });
+    }
+    else {
+      alert("Dados inválidos.");
+    }
+  }
+
+
+}


### PR DESCRIPTION
Através do botão de editar, presente na relação de cargos, possibilite ao usuário a operação de edição. O botão de editar deve redirecionar o usuário para uma página com formulário para editar o cargo, onde os campos devem ser preenchidos automaticamente com as informações desse cargo. Implemente no componente e no serviço de cargo o método para editar, update. Implemente o tratamento de erro com catchError. Ao efetuar a operação, o usuário deve ser direcionado, automaticamente de volta, para a relação.