### PR TITLE
spinner implementado na página relação-chamados para melhor navegação do usuário

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,3 +8,4 @@ import { Component } from '@angular/core';
 export class AppComponent {
   title = 'helpr-front';
 }
+

--- a/src/app/shared/material/material.module.ts
+++ b/src/app/shared/material/material.module.ts
@@ -6,6 +6,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatListModule } from '@angular/material/list';
 import { MatTableModule } from '@angular/material/table';
 import { MatSelectModule } from '@angular/material/select';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 
 @NgModule({
   exports: [
@@ -15,7 +16,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatToolbarModule,
     MatListModule,
     MatTableModule,
-    MatSelectModule
+    MatSelectModule,
+    MatProgressSpinnerModule
   ]
 })
 export class MaterialModule { }

--- a/src/app/views/chamados/chamados.module.ts
+++ b/src/app/views/chamados/chamados.module.ts
@@ -3,6 +3,7 @@ import { MaterialModule } from './../../shared/material/material.module';
 import { ComponentsModule } from './../../components/components.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 import { ChamadosRoutingModule } from './chamados-routing.module';
 import { ChamadosComponent } from './chamados/chamados.component';
@@ -22,7 +23,7 @@ import { EditChamadoComponent } from 'src/app/views/chamados/edit-chamado/edit-c
     ComponentsModule,
     MaterialModule,
     ReactiveFormsModule,
-    FormsModule
-  ]
+    FormsModule,
+    MatProgressSpinnerModule  ]
 })
 export class ChamadosModule { }

--- a/src/app/views/chamados/chamados/chamados.component.css
+++ b/src/app/views/chamados/chamados/chamados.component.css
@@ -9,3 +9,10 @@
 table {
     width: 100%;
 }
+
+.container-spinner {
+    display:flex;
+    align-items: center; 
+    justify-content: center;
+    padding: 40px;
+}

--- a/src/app/views/chamados/chamados/chamados.component.html
+++ b/src/app/views/chamados/chamados/chamados.component.html
@@ -1,7 +1,11 @@
 <app-nav-bar>
+    <div class="container-spinner"  *ngIf="spinner else table"><mat-spinner></mat-spinner></div>
+    <ng-template #table>
+
     <ng-container>
         <div class="container-title">
             <h2>Chamados</h2>
+ 
             <a mat-mini-fab color="primary" routerLink="new">
                 <i class="material-icons">add</i>
             </a>
@@ -60,4 +64,6 @@
             <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
         </table>
     </ng-container>
+    
+    </ng-template>
 </app-nav-bar>

--- a/src/app/views/chamados/chamados/chamados.component.ts
+++ b/src/app/views/chamados/chamados/chamados.component.ts
@@ -12,15 +12,25 @@ export class ChamadosComponent implements OnInit {
   displayedColumns: string[] = ['id', 'titulo', 'cliente', 'funcionario', 'dataAbertura', 'status', 'editar', 'detalhes'];
   dataSource: Chamado[] = [];
 
+  spinner: boolean = true
+
   constructor(private chamadoService: ChamadoService) { }
 
   ngOnInit(): void {
     this.initializeTable();
   }
 
-  private initializeTable(): void {
-    this.chamadoService.findAll().subscribe(chamados => {
+   private initializeTable(): void {
+   this.uploadTable();
+   this.chamadoService.findAll().subscribe(chamados => {
       this.dataSource = chamados;
     });
   }
+
+  private uploadTable(): void {
+    setTimeout(()=> this.chamadoService.findAll().subscribe(chamados => {
+      this.dataSource = chamados;
+      this.spinner = false; 
+  }), 500)
+}
 }


### PR DESCRIPTION
Na página com relação de chamados, a tabela possui um delay no carregamento dos dados de chamados. Com Angular Material, implemente um componente visual para efeito de carregamento dos dados para possibilitar uma melhor experiência ao usuário. Para isso utilize o Progress Spinner que deve aparecer em detrimento da condição de carregamento dos dados.
Recursos: https://material.angular.io/components/progress-spinner/examples#progress-spinner-overview

---
*Obs: Implementação da nomenclatura 'feat' -  boa prática para indicar inclusão de novo recurso.